### PR TITLE
Fix MIPS and PPC64 architecture definitions

### DIFF
--- a/avatar2/archs/mips.py
+++ b/avatar2/archs/mips.py
@@ -10,6 +10,9 @@ from avatar2.installer.config import QEMU, PANDA, OPENOCD, GDB_MULTI
 
 class MIPS32(Architecture):
 
+    qemu_name = 'mips'
+    gdb_name = 'mips'
+
     get_qemu_executable = Architecture.resolve(QEMU)
     get_panda_executable = Architecture.resolve(PANDA)
     get_gdb_executable  = Architecture.resolve(GDB_MULTI)

--- a/avatar2/archs/powerpc.py
+++ b/avatar2/archs/powerpc.py
@@ -56,7 +56,7 @@ class PPC32(PPCBase):
 class PPC64(PPCBase):
     """64-bit PowerPC."""
     qemu_name = "ppc64"
-    gdb_name = "powerpc64:common"
+    gdb_name = "powerpc:common64"
     endian = "big"
     capstone_mode = CS_MODE_BIG_ENDIAN | CS_MODE_64
     keystone_mode = KS_MODE_PPC64


### PR DESCRIPTION
mips.py:
- Add qemu_name='mips' and gdb_name='mips' to MIPS32 base class (required by avatar-qemu configurable machine for CPU creation)

powerpc.py:
- Fix PPC64 gdb_name from 'powerpc64:common' to 'powerpc:common64' (GDB doesn't recognize 'powerpc64:common')