### PR TITLE
Updated to use capstone 6+ as 6 introduces breaking change

### DIFF
--- a/avatar2/archs/arm.py
+++ b/avatar2/archs/arm.py
@@ -115,7 +115,7 @@ class ARM64(Architecture):
     pc_name = 'pc'
     sr_name = 'nzcv'
     unemulated_instructions = ['mcr', 'mrc']
-    capstone_arch = CS_ARCH_ARM64
+    capstone_arch = CS_ARCH_AARCH64
     capstone_mode = CS_MODE_LITTLE_ENDIAN
     keystone_arch = KS_ARCH_ARM64
     unicorn_arch = UC_ARCH_ARM64

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'cached_property;python_version<="3.8"',
         'intervaltree',
         'posix_ipc>=1.0.0',
-        'capstone>=3.0.4',
+        'capstone>=5',
         'keystone-engine',
         'parse',
         'configparser',
@@ -30,6 +30,7 @@ setup(
         'bitstring',
         'pylink-square',
         'pyusb',
+        'setuptools<81'
     ],
     include_package_data=True,
     url='https://github.com/avatartwo/avatar2',


### PR DESCRIPTION
Update to use capstone >5 and pin version of setuptools.  Updated use of CS_ARCH_ARM64 to CS_ARCH_AARCH64